### PR TITLE
feat: add cobra cmd to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ func main() {
 }
 ```
 
-### Configuration
+### CommandWithConfig
 
 Ecdysis provides an automatic way to parse a configuration file, environment variables, and flags using the [`viper`](https://github.com/spf13/viper) library. To use it, you need to implement the `CommandWithConfig` interface.
 
@@ -122,7 +122,9 @@ The order of precedence for configuration values is:
 
 ```go
 var (
-    _ ecdysis.CommandWithConfiguration = (*RootCommand)(nil)
+    _ ecdysis.CommandWithFlags   = (*RootCommand)(nil)
+    _ ecdysis.CommandWithExecute = (*RootCommand)(nil)
+    _ ecdysis.CommandWithConfig  = (*RootCommand)(nil)
 )
 
 type ConduitConfig struct {
@@ -144,12 +146,12 @@ type RootCommand struct {
     cfg   ConduitConfig
 }
 
-func (c *RootCommand) ParseConfig() ecdysis.Config {
+func (c *RootCommand) Config() ecdysis.Config {
     return ecdysis.Config{
-        EnvPrefix:  "CONDUIT", // prefix for environment variables
-        ParsedCfg:  &c.cfg, // where configuration will be parsed
-        ConfigPath: c.flags.ConduitCfgPath, // where to read the configuration file
-        DefaultCfg: c.cfg, // where to extract default values from
+        EnvPrefix:     "CONDUIT",
+        Parsed:        &c.Cfg,
+        Path:          c.flags.ConduitCfgPath,
+        DefaultValues: conduit.DefaultConfigWithBasePath(path),
     }
 }
 
@@ -168,6 +170,23 @@ func (c *RootCommand) Flags() []ecdysis.Flag {
     return flags
 }
 ````
+
+### Fetching cobra.Command from CommandWithExecute
+
+If you need to access the `cobra.Command` instance from a `CommandWithExecute` implementation, you can utilize
+the `ecdysis.CobraCmdFromContext` function to fetch it from the context:
+
+```go
+func (c *RootCommand) Execute(ctx context.Context) error {
+    if cmd := ecdysis.CobraCmdFromContext(ctx); cmd != nil {
+        return cmd.Help()
+    }
+    return nil
+}
+```
+
+```go
+
 
 ## Flags
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ func (c *RootCommand) Flags() []ecdysis.Flag {
 	
     return flags
 }
-````
+```
 
-### Fetching cobra.Command from CommandWithExecute
+### Fetching `cobra.Command` from `CommandWithExecute`
 
 If you need to access the `cobra.Command` instance from a `CommandWithExecute` implementation, you can utilize
 the `ecdysis.CobraCmdFromContext` function to fetch it from the context:
@@ -184,9 +184,6 @@ func (c *RootCommand) Execute(ctx context.Context) error {
     return nil
 }
 ```
-
-```go
-
 
 ## Flags
 

--- a/context.go
+++ b/context.go
@@ -32,7 +32,7 @@ func contextWithCobraCommand(ctx context.Context, cmd *cobra.Command) context.Co
 // context does not contain a cobra command, it returns nil.
 func CobraCmdFromContext(ctx context.Context) *cobra.Command {
 	if cobraCmd := ctx.Value(cobraCmdCtxKey{}); cobraCmd != nil {
-		return cobraCmd.(*cobra.Command)
+		return cobraCmd.(*cobra.Command) //nolint:forcetypeassert // only this package can set the value, it has to be a *cobra.Command
 	}
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -1,0 +1,38 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecdysis
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+type cobraCmdCtxKey struct{}
+
+// contextWithCobraCommand provides the cobra command to the context.
+// This is useful for situations such as wanting to execute cmd.Help() directly from Execute().
+func contextWithCobraCommand(ctx context.Context, cmd *cobra.Command) context.Context {
+	return context.WithValue(ctx, cobraCmdCtxKey{}, cmd)
+}
+
+// CobraCmdFromContext fetches the cobra command from the context. If the
+// context does not contain a cobra command, it returns nil.
+func CobraCmdFromContext(ctx context.Context) *cobra.Command {
+	if cobraCmd := ctx.Value(cobraCmdCtxKey{}); cobraCmd != nil {
+		return cobraCmd.(*cobra.Command)
+	}
+	return nil
+}

--- a/decorators.go
+++ b/decorators.go
@@ -621,8 +621,6 @@ type CommandWithExecute interface {
 // CommandWithExecuteDecorator is a decorator that sets the command execution.
 type CommandWithExecuteDecorator struct{}
 
-type CobraCtxCmd struct{}
-
 // Decorate sets the command execution.
 func (CommandWithExecuteDecorator) Decorate(_ *Ecdysis, cmd *cobra.Command, c Command) error {
 	v, ok := c.(CommandWithExecute)
@@ -639,9 +637,7 @@ func (CommandWithExecuteDecorator) Decorate(_ *Ecdysis, cmd *cobra.Command, c Co
 			}
 		}
 
-		// Provide the cobra command to the context.
-		// This is useful for situations such as wanting to execute cmd.Help() directly from Execute().
-		ctx := context.WithValue(cmd.Context(), CobraCtxCmd{}, cmd)
+		ctx := contextWithCobraCommand(cmd.Context(), cmd)
 		return v.Execute(ctx)
 	}
 

--- a/decorators.go
+++ b/decorators.go
@@ -621,6 +621,8 @@ type CommandWithExecute interface {
 // CommandWithExecuteDecorator is a decorator that sets the command execution.
 type CommandWithExecuteDecorator struct{}
 
+type CobraCtxCmd struct{}
+
 // Decorate sets the command execution.
 func (CommandWithExecuteDecorator) Decorate(_ *Ecdysis, cmd *cobra.Command, c Command) error {
 	v, ok := c.(CommandWithExecute)
@@ -636,7 +638,11 @@ func (CommandWithExecuteDecorator) Decorate(_ *Ecdysis, cmd *cobra.Command, c Co
 				return err
 			}
 		}
-		return v.Execute(cmd.Context())
+
+		// Provide the cobra command to the context.
+		// This is useful for situations such as wanting to execute cmd.Help() directly from Execute().
+		ctx := context.WithValue(cmd.Context(), CobraCtxCmd{}, cmd)
+		return v.Execute(ctx)
 	}
 
 	return nil

--- a/ecdysis_test.go
+++ b/ecdysis_test.go
@@ -110,7 +110,11 @@ type BehavioralTestCommand interface {
 
 func TestBuildCobraCommand_Behavioral(t *testing.T) {
 	ctx := context.Background()
+	cobraCmd := &cobra.Command{}
+	ctx = context.WithValue(ctx, CobraCtxCmd{}, cobraCmd)
+
 	ctrl := gomock.NewController(t)
+
 	cmd := NewMockBehavioralTestCommand(ctrl)
 
 	wantLogger := slog.New(slog.NewTextHandler(nil, nil))
@@ -124,7 +128,7 @@ func TestBuildCobraCommand_Behavioral(t *testing.T) {
 
 	// Set up the remaining expectations before executing the command.
 	call = cmd.EXPECT().Args(gomock.Any()).Return(nil).After(call)
-	cmd.EXPECT().Execute(ctx).Return(nil).After(call)
+	cmd.EXPECT().Execute(gomock.AssignableToTypeOf(ctx)).Return(nil).After(call)
 
 	err := got.ExecuteContext(ctx)
 	if err != nil {

--- a/ecdysis_test.go
+++ b/ecdysis_test.go
@@ -110,12 +110,9 @@ type BehavioralTestCommand interface {
 
 func TestBuildCobraCommand_Behavioral(t *testing.T) {
 	ctx := context.Background()
-	cobraCmd := &cobra.Command{}
-	ctx = context.WithValue(ctx, CobraCtxCmd{}, cobraCmd)
-
 	ctrl := gomock.NewController(t)
-
 	cmd := NewMockBehavioralTestCommand(ctrl)
+	ctx = context.WithValue(ctx, CobraCtxCmd{}, cmd)
 
 	wantLogger := slog.New(slog.NewTextHandler(nil, nil))
 	ecdysis := New(WithDecorators(CommandWithLoggerDecorator{Logger: wantLogger}))

--- a/ecdysis_test.go
+++ b/ecdysis_test.go
@@ -112,7 +112,7 @@ func TestBuildCobraCommand_Behavioral(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	cmd := NewMockBehavioralTestCommand(ctrl)
-	ctx = context.WithValue(ctx, CobraCtxCmd{}, cmd)
+	ctx = context.WithValue(ctx, cobraCmdCtxKey{}, cmd)
 
 	wantLogger := slog.New(slog.NewTextHandler(nil, nil))
 	ecdysis := New(WithDecorators(CommandWithLoggerDecorator{Logger: wantLogger}))


### PR DESCRIPTION
This could be useful on situations such as invoking a native cobra command (e.g.: `help`):

```golang
func (c *RootCommand) Execute(ctx context.Context) error {
	if c.flags.Version {
		_, _ = fmt.Fprintf(os.Stdout, "%s\n", conduit.Version(true))
		return nil
	}

	if cmd, ok := ctx.Value(ecdysis.CobraCtxCmd{}).(*cobra.Command); ok {
		return cmd.Help()
	}

	return nil
}
```

An alternative I had in mind was having another decorator named `ExecuteWithCobraCommand` which would be `ExecuteWithCobraCommand(ctx context.Context, cmd *cobra.Command) error`, but I'm not sure I'm in love with the idea of having two separate `Execute` methods. For situations like this one, it could be useful simply use the context.