### PR TITLE
feat: make ContextWithCobraCommand public

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@
 package ecdysis
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -93,21 +94,17 @@ func parseConfig(v *viper.Viper, cfg Config, cmd *cobra.Command) error {
 		}
 	}
 
-	var errors []error
+	var errs []error
 
 	// Handle flags
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		if err := v.BindPFlag(f.Name, f); err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		}
 	})
 
-	if len(errors) > 0 {
-		var errStrs []string
-		for _, err := range errors {
-			errStrs = append(errStrs, err.Error())
-		}
-		return fmt.Errorf("error binding flags: %s", strings.Join(errStrs, "; "))
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("error binding flags: %w", err)
 	}
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -22,9 +22,9 @@ import (
 
 type cobraCmdCtxKey struct{}
 
-// contextWithCobraCommand provides the cobra command to the context.
+// ContextWithCobraCommand provides the cobra command to the context.
 // This is useful for situations such as wanting to execute cmd.Help() directly from Execute().
-func contextWithCobraCommand(ctx context.Context, cmd *cobra.Command) context.Context {
+func ContextWithCobraCommand(ctx context.Context, cmd *cobra.Command) context.Context {
 	return context.WithValue(ctx, cobraCmdCtxKey{}, cmd)
 }
 

--- a/decorators.go
+++ b/decorators.go
@@ -637,7 +637,7 @@ func (CommandWithExecuteDecorator) Decorate(_ *Ecdysis, cmd *cobra.Command, c Co
 			}
 		}
 
-		ctx := contextWithCobraCommand(cmd.Context(), cmd)
+		ctx := ContextWithCobraCommand(cmd.Context(), cmd)
 		return v.Execute(ctx)
 	}
 


### PR DESCRIPTION
Needed for `ExecuteWithClient` implemented on https://github.com/ConduitIO/conduit/pull/2063.