### PR TITLE
fix: Not reading from the right configuration file when using `CONDUIT_CONFIG_PATH`

### DIFF
--- a/config.go
+++ b/config.go
@@ -85,9 +85,12 @@ func bindViperConfig(v *viper.Viper, cfg Config, cmd *cobra.Command) error {
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
+	// cfg.EnvPrefix will contain the desired prefix for the environment variables.
+	configPathEnvVar := fmt.Sprintf("%s_CONFIG_PATH", cfg.EnvPrefix)
+
 	// Reads from that configuration if it's specified via environment variable
-	if os.Getenv("CONDUIT_CONFIG_PATH") != "" {
-		cfg.Path = os.Getenv("CONDUIT_CONFIG_PATH")
+	if os.Getenv(configPathEnvVar) != "" {
+		cfg.Path = os.Getenv(configPathEnvVar)
 	}
 
 	v.SetConfigFile(cfg.Path)

--- a/config.go
+++ b/config.go
@@ -88,7 +88,7 @@ func bindViperConfig(v *viper.Viper, cfg Config, cmd *cobra.Command) error {
 	// cfg.EnvPrefix will contain the desired prefix for the environment variables.
 	configPathEnvVar := fmt.Sprintf("%s_CONFIG_PATH", cfg.EnvPrefix)
 
-	// Reads from that configuration if it's specified via environment variable
+	// Reads from that configuration if it's specified via environment variable.
 	if os.Getenv(configPathEnvVar) != "" {
 		cfg.Path = os.Getenv(configPathEnvVar)
 	}

--- a/config.go
+++ b/config.go
@@ -85,6 +85,11 @@ func bindViperConfig(v *viper.Viper, cfg Config, cmd *cobra.Command) error {
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
+	// Reads from that configuration if it's specified via environment variable
+	if os.Getenv("CONDUIT_CONFIG_PATH") != "" {
+		cfg.Path = os.Getenv("CONDUIT_CONFIG_PATH")
+	}
+
 	v.SetConfigFile(cfg.Path)
 	v.SetConfigType("yaml")
 

--- a/config_test.go
+++ b/config_test.go
@@ -121,12 +121,12 @@ func TestParseConfig_NameWithDash_Default(t *testing.T) {
 	is.Equal(cookCmd.Cfg, cookingConfig{HeatLevel: 5})
 }
 
-// customCookCommand is a command that uses a custom environment prefix for testing
+// customCookCommand is a command that uses a custom environment prefix for testing.
 type customCookCommand struct {
 	cookCommand
 }
 
-// Config returns a configuration with a custom environment prefix
+// Config returns a configuration with a custom environment prefix.
 func (c *customCookCommand) Config() Config {
 	cfg := c.cookCommand.Config()
 	cfg.EnvPrefix = "MY_ENV"
@@ -143,7 +143,7 @@ func TestParseConfig_CustomConfigPath(t *testing.T) {
 
 	// Write custom config to the temporary file
 	customHeatLevel := 42
-	_, err = customConfigFile.WriteString(fmt.Sprintf("heat-level: %d\n", customHeatLevel))
+	_, err = fmt.Fprintf(customConfigFile, "heat-level: %d\n", customHeatLevel)
 	is.NoErr(err)
 	err = customConfigFile.Close()
 	is.NoErr(err)

--- a/config_test.go
+++ b/config_test.go
@@ -121,6 +121,18 @@ func TestParseConfig_NameWithDash_Default(t *testing.T) {
 	is.Equal(cookCmd.Cfg, cookingConfig{HeatLevel: 5})
 }
 
+// customCookCommand is a command that uses a custom environment prefix for testing
+type customCookCommand struct {
+	cookCommand
+}
+
+// Config returns a configuration with a custom environment prefix
+func (c *customCookCommand) Config() Config {
+	cfg := c.cookCommand.Config()
+	cfg.EnvPrefix = "MY_ENV"
+	return cfg
+}
+
 func TestParseConfig_CustomConfigPath(t *testing.T) {
 	is := is.New(t)
 
@@ -136,12 +148,12 @@ func TestParseConfig_CustomConfigPath(t *testing.T) {
 	err = customConfigFile.Close()
 	is.NoErr(err)
 
-	// Set CONDUIT_CONFIG_PATH environment variable to the temporary file path
-	t.Setenv("CONDUIT_CONFIG_PATH", customConfigFile.Name())
+	// Set MY_ENV_CONFIG_PATH environment variable to the temporary file path
+	t.Setenv("MY_ENV_CONFIG_PATH", customConfigFile.Name())
 
 	// Execute the command and verify the config was loaded from the custom path
-	cookCmd := &cookCommand{}
-	cookCobraCmd := New().MustBuildCobraCommand(cookCmd)
+	customCmd := &customCookCommand{}
+	cookCobraCmd := New().MustBuildCobraCommand(customCmd)
 	is.NoErr(cookCobraCmd.Execute())
-	is.Equal(cookCmd.Cfg, cookingConfig{HeatLevel: customHeatLevel})
+	is.Equal(customCmd.Cfg, cookingConfig{HeatLevel: customHeatLevel})
 }


### PR DESCRIPTION
Closes #25

(reported by @rauanmayemir [on Discord](https://discord.com/channels/828680256877363200/1360147516703637666/1360197069473710100)).

> [!NOTE]  
> Once it ships, this will require a new conduit release to make it available to everyone.